### PR TITLE
add getManifest endpoint for jellyscrub

### DIFF
--- a/src/source/api.brs
+++ b/src/source/api.brs
@@ -826,12 +826,16 @@ function introskipperActions()
     return instance
 end function
 
-function jellyscrubActions()
+function api_jellyscrubActions()
     instance = {}
-
+    
     ' Get jelly scrub plugin data
-    instance.get = function(id as string)
-        return _buildURL(Substitute("/Trickplay/{0}/320/GetBIF?apikey={1}", id, config().APIKEY))
+    instance.getManifest = function(id as string)
+        return _api_buildURL(Substitute("/Trickplay/{0}/GetManifest?apikey={1}", id, api_config().APIKEY))
+    end function
+
+    instance.getBif = function(id as string, width as string)
+        return _api_buildURL(Substitute("/Trickplay/{0}/{1}/GetBIF?apikey={2}", id, width, api_config().APIKEY))
     end function
 
     return instance

--- a/src/source/api.brs
+++ b/src/source/api.brs
@@ -830,11 +830,12 @@ function jellyscrubActions()
     instance = {}
 
     ' Get jelly scrub plugin data
-    instance.getManifest = function(id as string)
-        return _buildURL(Substitute("/Trickplay/{0}/GetManifest?apikey={1}", id, api_config().APIKEY))
+    instance.getmanifest = function(id as string)
+        req = _APIRequest(Substitute("/Trickplay/{0}/GetManifest?apikey={1}", id, api_config().APIKEY))
+        return = _getJson(req)
     end function
 
-    instance.getBif = function(id as string, width as string)
+    instance.getbifurl = function(id as string, width as string)
         return _buildURL(Substitute("/Trickplay/{0}/{1}/GetBIF?apikey={2}", id, width, api_config().APIKEY))
     end function
 

--- a/src/source/api.brs
+++ b/src/source/api.brs
@@ -832,7 +832,7 @@ function jellyscrubActions()
     ' Get jelly scrub plugin data
     instance.getmanifest = function(id as string)
         req = _APIRequest(Substitute("/Trickplay/{0}/GetManifest?apikey={1}", id, api_config().APIKEY))
-        return = _getJson(req)
+        return _getJson(req)
     end function
 
     instance.getbifurl = function(id as string, width as string)

--- a/src/source/api.brs
+++ b/src/source/api.brs
@@ -828,7 +828,7 @@ end function
 
 function jellyscrubActions()
     instance = {}
-    
+
     ' Get jelly scrub plugin data
     instance.getManifest = function(id as string)
         return _buildURL(Substitute("/Trickplay/{0}/GetManifest?apikey={1}", id, api_config().APIKEY))

--- a/src/source/api.brs
+++ b/src/source/api.brs
@@ -826,16 +826,16 @@ function introskipperActions()
     return instance
 end function
 
-function api_jellyscrubActions()
+function jellyscrubActions()
     instance = {}
     
     ' Get jelly scrub plugin data
     instance.getManifest = function(id as string)
-        return _api_buildURL(Substitute("/Trickplay/{0}/GetManifest?apikey={1}", id, api_config().APIKEY))
+        return _buildURL(Substitute("/Trickplay/{0}/GetManifest?apikey={1}", id, api_config().APIKEY))
     end function
 
     instance.getBif = function(id as string, width as string)
-        return _api_buildURL(Substitute("/Trickplay/{0}/{1}/GetBIF?apikey={2}", id, width, api_config().APIKEY))
+        return _buildURL(Substitute("/Trickplay/{0}/{1}/GetBIF?apikey={2}", id, width, api_config().APIKEY))
     end function
 
     return instance


### PR DESCRIPTION
adds getManifest endoint.  get renamed to getbifurl and now requires width to be passed as a string